### PR TITLE
Add `horizon:publish` to Composer update script hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -113,6 +113,9 @@
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
         ],
+        "post-update-cmd": [
+            "@php artisan horizon:publish --ansi"
+        ],
         "enlightn": "@php artisan enlightn --details --ci",
         "fix": [
             "vendor/bin/php-cs-fixer fix --using-cache=no --config=.php_cs.dist"


### PR DESCRIPTION
As mentioned by @lorisleiva in https://github.com/Astrotomic/opendor.me/issues/44#issuecomment-820962876, maybe the horizon:publish command shouldn't be in the production deploy script.

This PR puts it so that it runs when `composer update` is run, presumably on a dev machine.
It's also recommended in the Laravel docs: https://laravel.com/docs/8.x/horizon#upgrading-horizon