### PR TITLE
FAQ Improvements

### DIFF
--- a/content/faqs/what-is-the-point-of-opendorme.md
+++ b/content/faqs/what-is-the-point-of-opendorme.md
@@ -1,7 +1,7 @@
 ---
 slug: what-is-the-point-of-opendorme
 priority: 100
-question: 'What is the point of Opendor.me?'
+question: 'What is the point of opendor.me?'
 is_draft: false
 ---
 Our goal is to help open-source contributors share and highlight their open-source work. We know how hard open-source work can be, but we also know how rewarding it can be.

--- a/resources/views/components/web/faqs.blade.php
+++ b/resources/views/components/web/faqs.blade.php
@@ -10,7 +10,7 @@
                         <dt class="text-lg font-medium leading-6 text-gray-900">
                             {{ $faq->question }}
                         </dt>
-                        <dd class="mt-2 text-base text-gray-500">
+                        <dd class="text-base text-gray-500 whitespace-pre-line">
                             {!! \Illuminate\Support\Str::markdown($faq->content) !!}
                         </dd>
                     </div>


### PR DESCRIPTION
This PR fixes the spelling of "Opendor.me" to "opendor.me" to be consistent with the rest of the site and other FAQs. It also adds the "whitespace-pre-line" class to the FAQ content so that line breaks are rendered appropriately, making the FAQs look a bit neater.