### PR TITLE
Add og tags to sponsor, faq and profile page

### DIFF
--- a/app/View/Components/OpenGraph/Website.php
+++ b/app/View/Components/OpenGraph/Website.php
@@ -18,7 +18,7 @@ class Website extends Component
     ) {
         $this->title = $this->title
             ? Str::finish($this->title, ' | '.config('app.name'))
-            : null;
+            : config('app.name');
     }
 
     public function render(): Htmlable
@@ -27,6 +27,7 @@ class Website extends Component
             OpenGraph::website($this->title)
                 ->locale(app()->getLocale())
                 ->siteName(config('app.name'))
+                ->title($this->title)
                 ->url($this->url ?? request()->url())
                 ->when($this->description)->description($this->description)
                 ->when($this->image)->image($this->image)

--- a/app/View/Components/Twitter.php
+++ b/app/View/Components/Twitter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\View\Components;
+
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HtmlString;
+use Illuminate\View\Component;
+
+class Twitter extends Component
+{
+    public function render(): Htmlable
+    {
+        return new HtmlString(
+            \Astrotomic\OpenGraph\Twitter::summary(config('app.name'))
+                                         ->title(config('app.name'))
+        );
+    }
+}

--- a/resources/views/web/faqs.blade.php
+++ b/resources/views/web/faqs.blade.php
@@ -1,3 +1,9 @@
+@push('head')
+    <meta name="description" content="We open doors for open-source contributors and make open-source visible and understandable for everyone and show recruiters the open-source work of a potential candidate."/>
+
+    <x-open-graph.website :image="asset('images/og-home.png')"/>
+@endpush
+
 <x-layout.web page-title="Frequently Asked Questions">
 
     <x-web.faqs/>

--- a/resources/views/web/faqs.blade.php
+++ b/resources/views/web/faqs.blade.php
@@ -2,6 +2,7 @@
     <meta name="description" content="We open doors for open-source contributors and make open-source visible and understandable for everyone and show recruiters the open-source work of a potential candidate."/>
 
     <x-open-graph.website :image="asset('images/og-home.png')"/>
+    <x-twitter/>
 @endpush
 
 <x-layout.web page-title="Frequently Asked Questions">

--- a/resources/views/web/home.blade.php
+++ b/resources/views/web/home.blade.php
@@ -2,6 +2,7 @@
     <meta name="description" content="We open doors for open-source contributors and make open-source visible and understandable for everyone and show recruiters the open-source work of a potential candidate."/>
 
     <x-open-graph.website :image="asset('images/og-home.png')"/>
+    <x-twitter/>
 @endpush
 
 <x-layout.web>

--- a/resources/views/web/profile/user.blade.php
+++ b/resources/views/web/profile/user.blade.php
@@ -2,6 +2,7 @@
     <meta name="description" content="{{ config('app.name') }} profile of {{ $user->name }}."/>
 
     <x-open-graph.website :image="$user->avatar_url"/>
+    <x-twitter/>
 @endpush
 
 <x-layout.web :page-title="$user->name" class="py-10">

--- a/resources/views/web/profile/user.blade.php
+++ b/resources/views/web/profile/user.blade.php
@@ -1,3 +1,9 @@
+@push('head')
+    <meta name="description" content="{{ config('app.name') }} profile of {{ $user->name }}."/>
+
+    <x-open-graph.website :image="$user->avatar_url"/>
+@endpush
+
 <x-layout.web :page-title="$user->name" class="py-10">
     <div class="flex flex-col px-4 mx-auto space-y-3 max-w-3xl sm:px-6 lg:max-w-7xl lg:px-8">
         <div class="flex items-center space-x-5">

--- a/resources/views/web/sponsors.blade.php
+++ b/resources/views/web/sponsors.blade.php
@@ -1,3 +1,9 @@
+@push('head')
+    <meta name="description" content="We open doors for open-source contributors and make open-source visible and understandable for everyone and show recruiters the open-source work of a potential candidate."/>
+
+    <x-open-graph.website :image="asset('images/og-home.png')"/>
+@endpush
+
 <x-layout.web page-title="Sponsors">
 
     <x-web.github-sponsors/>

--- a/resources/views/web/sponsors.blade.php
+++ b/resources/views/web/sponsors.blade.php
@@ -2,6 +2,7 @@
     <meta name="description" content="We open doors for open-source contributors and make open-source visible and understandable for everyone and show recruiters the open-source work of a potential candidate."/>
 
     <x-open-graph.website :image="asset('images/og-home.png')"/>
+    <x-twitter/>
 @endpush
 
 <x-layout.web page-title="Sponsors">


### PR DESCRIPTION
Closes #4 

This PR adds opengraph tags to sponsor, faq and profile pages.

For profile pages use the avatar image provided by Github. For the other pages it uses the same settings as for the home page.