### PR TITLE
fix: readme github setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ The following tools are required in order to start the installation.
 To get Github authentication to work locally, you'll need to [register a new OAuth application on Github](https://github.com/settings/applications/new). Use `http://localhost:8080` for the homepage url and `http://localhost:8000/auth/github/callback` for the callback url. When you've created the app, fill in the ID and secret in your `.env` file in the env variables below. You should now be able to authentication with Github.
 
 ```
-GITHUB_ID=
-GITHUB_SECRET=
-GITHUB_URL=http://localhost:8080/github/callback
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
 ```
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The following tools are required in order to start the installation.
 
 ### Github Setup
 
-To get Github authentication to work locally, you'll need to [register a new OAuth application on Github](https://github.com/settings/applications/new). Use `http://localhost:8080` for the homepage url and `http://lcoalhost:8000/auth/github/callback` for the callback url. When you've created the app, fill in the ID and secret in your `.env` file in the env variables below. You should now be able to authentication with Github.
+To get Github authentication to work locally, you'll need to [register a new OAuth application on Github](https://github.com/settings/applications/new). Use `http://localhost:8080` for the homepage url and `http://localhost:8000/auth/github/callback` for the callback url. When you've created the app, fill in the ID and secret in your `.env` file in the env variables below. You should now be able to authentication with Github.
 
 ```
 GITHUB_ID=


### PR DESCRIPTION
1. There is typo on `http://lcoalhost`.
2. The env keys suggested do not match with the [expected by Socialite](https://github.com/Astrotomic/opendor.me/blob/dev/config/services.php#L33).

Fix #121 